### PR TITLE
Enable GitHub user registration on login

### DIFF
--- a/src/main/java/codesumn/com/marketplace_backend/infrastructure/adapters/persistence/repository/UserRepository.java
+++ b/src/main/java/codesumn/com/marketplace_backend/infrastructure/adapters/persistence/repository/UserRepository.java
@@ -11,5 +11,7 @@ import java.util.UUID;
 @Repository
 public interface UserRepository extends JpaRepository<UserModel, UUID>, JpaSpecificationExecutor<UserModel> {
     Optional<UserModel> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }
 


### PR DESCRIPTION
- Introduce logic to create a new user during GitHub authentication if the email does not exist in the database.
- Add `existsByEmail` method to `UserRepository` for email existence checks.
- Set default user properties, including role, for new GitHub users.
- Save new users to the database and continue token generation process.